### PR TITLE
Add dynamic projects API and context; integrate into UI

### DIFF
--- a/api/projects.js
+++ b/api/projects.js
@@ -1,0 +1,28 @@
+export default async function handler(req, res) {
+  const repos = [
+    "PAC-MAN"
+  ]; 
+  const githubUser = 'anritsetskhla10';
+
+  try {
+    if (repos.length === 0) {
+      return res.status(200).json([]);
+    }
+
+    const promises = repos.map(async (repoName) => {
+      const response = await fetch(`https://raw.githubusercontent.com/${githubUser}/${repoName}/main/portfolio.json`);
+      if (!response.ok) return null;
+      
+      const data = await response.json();
+      return { ...data, repoName }; 
+    });
+
+    const results = await Promise.all(promises);
+    const validProjects = results.filter(p => p !== null);
+
+    res.status(200).json(validProjects);
+  } catch (error) {
+    console.error('Error fetching projects:', error);
+    res.status(500).json({ error: 'Failed to fetch projects' });
+  }
+}

--- a/context/ProjectsContext.jsx
+++ b/context/ProjectsContext.jsx
@@ -1,0 +1,34 @@
+import{ createContext, useState, useEffect } from 'react';
+import { PROJECTS as LOCAL_PROJECTS } from '../src/constants/index';
+
+export const ProjectsContext = createContext();
+// eslint-disable-next-line react/prop-types
+export const ProjectsProvider = ({ children }) => {
+
+  const [projects, setProjects] = useState(LOCAL_PROJECTS);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchDynamicProjects = async () => {
+      try {
+        const response = await fetch('/api/projects');
+        if (response.ok) {
+          const dynamicProjects = await response.json();
+          setProjects([...LOCAL_PROJECTS, ...dynamicProjects]);
+        }
+      } catch (err) {
+        console.error("ვერ მოხერხდა ახალი პროექტების წამოღება:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDynamicProjects();
+  }, []);
+
+  return (
+    <ProjectsContext.Provider value={{ projects, loading }}>
+      {children}
+    </ProjectsContext.Provider>
+  );
+};

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,11 +1,17 @@
-import React from 'react'
-import { PROJECTS } from '../constants'
-import { motion } from "framer-motion"
-import { Link } from "react-router-dom"
-import { useTranslation } from 'react-i18next'
+import  { useContext } from 'react';
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+import { useTranslation } from 'react-i18next';
+import { ProjectsContext } from '../../context/ProjectsContext';
+
+const GITHUB_USER = 'anritsetskhla10';
 
 const Projects = () => {
   const { t } = useTranslation();
+  const { projects, loading } = useContext(ProjectsContext);
+
+  if (loading) return <div className="text-center my-8">იტვირთება მონაცემები...</div>;
+
   return (
     <div className='border-b border-neutral-400 pb-4'>
       <motion.h2
@@ -18,8 +24,17 @@ const Projects = () => {
       </motion.h2>
 
       <div className='flex flex-wrap'>
-        {PROJECTS.map((project, index) => {
-          const slug = project.title.toLowerCase().replace(/\s+/g, '-')
+        {projects.map((project, index) => {
+          const isDynamic = !!project.repoName;
+          
+          const slug = isDynamic 
+            ? project.repoName 
+            : project.title.toLowerCase().replace(/\s+/g, '-');
+            
+          const mainImageUrl = isDynamic 
+            ? `https://raw.githubusercontent.com/${GITHUB_USER}/${project.repoName}/main/screenshots/1.png`
+            : project.image;
+
           return (
             <Link
               to={`/projects/${slug}`}
@@ -27,7 +42,6 @@ const Projects = () => {
               className='w-full md:w-1/2 p-4'
             >
               <div className='flex flex-col md:flex-row items-start gap-6 rounded-lg p-4 transition hover:bg-neutral-800 h-full'>
-                {/* Image from left */}
                 <motion.div
                   whileInView={{ opacity: 1, x: 0 }}
                   initial={{ opacity: 0, x: -100 }}
@@ -35,15 +49,15 @@ const Projects = () => {
                   className='w-full md:w-1/3 flex justify-center items-center'
                 >
                   <img
-                    src={project.image}
+                    src={mainImageUrl}
                     alt={project.title}
                     width={150}
                     height={150}
-                    className='rounded'
+                    className='rounded object-cover'
+                    onError={(e) => { e.currentTarget.src = 'https://via.placeholder.com/150?text=No+Image'; }}
                   />
                 </motion.div>
 
-                {/* Title and Technologies from right */}
                 <motion.div
                   whileInView={{ opacity: 1, x: 0 }}
                   initial={{ opacity: 0, x: 100 }}
@@ -55,7 +69,7 @@ const Projects = () => {
                   </h3>
 
                   <div className='flex flex-wrap gap-2'>
-                    {project.technologies.map((tech, idx) => (
+                    {project.technologies?.map((tech, idx) => (
                       <span
                         key={idx}
                         className='px-2 py-1 rounded bg-neutral-900 text-sm font-medium text-purple-800'
@@ -74,4 +88,4 @@ const Projects = () => {
   )
 }
 
-export default Projects
+export default Projects;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,11 +4,14 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import './i18n';
 import "./index.css";
+import { ProjectsProvider } from "../context/ProjectsContext";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ProjectsProvider>
+        <App />
+      </ProjectsProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/ProjectDetails.jsx
+++ b/src/pages/ProjectDetails.jsx
@@ -1,34 +1,46 @@
-import React from "react";
+import { useState, useContext } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { PROJECTS } from "../constants";
 import { useTranslation } from "react-i18next";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation, Thumbs } from "swiper/modules";
+import { ProjectsContext } from '../../context/ProjectsContext';
 
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/thumbs";
 
-import { useState } from "react";
+const GITHUB_USER = 'anritsetskhla10';
 
 const ProjectDetails = () => {
   const { slug } = useParams();
   const navigate = useNavigate();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [thumbsSwiper, setThumbsSwiper] = useState(null);
 
-  const project = PROJECTS.find(
-    (p) => p.title.toLowerCase().replace(/\s+/g, "-") === slug
+  const { projects, loading } = useContext(ProjectsContext);
+
+  if (loading) return <div className="text-center mt-10">იტვირთება...</div>;
+
+  const project = projects.find(p => 
+    p.repoName === slug || p.title.toLowerCase().replace(/\s+/g, '-') === slug
   );
 
-  if (!project) return <div>{t("Project not found")}</div>;
+  if (!project) return <div className="text-center mt-10 text-red-500">{t("Project not found")}</div>;
+
+  const isDynamic = !!project.repoName;
+
+  const projectImages = isDynamic
+    ? Array.from({ length: project.imageCount || 1 }, (_, index) => `https://raw.githubusercontent.com/${GITHUB_USER}/${project.repoName}/main/screenshots/${index + 1}.png`)
+    : project.images;
+
+  const currentLang = i18n.language?.includes('ka') ? 'ka' : 'en';
+  const displayDescription = isDynamic 
+    ? project.description?.[currentLang] 
+    : t(`descriptions.${project.title}`);
 
   return (
     <div className="p-4">
-      <button
-        onClick={() => navigate(-1)}
-        className="text-black dark:text-purple-600 underline mb-4"
-      >
+      <button onClick={() => navigate(-1)} className="text-black dark:text-purple-600 underline mb-4">
         {t("Back to Projects")}
       </button>
 
@@ -43,12 +55,13 @@ const ProjectDetails = () => {
           loop={true}
           className="w-full max-w-md mb-4 rounded"
         >
-          {project.images.map((image, index) => (
+          {projectImages.map((image, index) => (
             <SwiperSlide key={index}>
               <img
                 src={image}
                 alt={`${project.title} ${index + 1}`}
                 className="w-full h-[400px] object-contain rounded bg-transparent"
+                onError={(e) => { e.currentTarget.src = 'https://via.placeholder.com/400x400?text=Image+Not+Found'; }}
               />
             </SwiperSlide>
           ))}
@@ -63,38 +76,31 @@ const ProjectDetails = () => {
           loop={true}
           className="w-full max-w-md"
         >
-          {project.images.map((image, index) => (
+          {projectImages.map((image, index) => (
             <SwiperSlide key={index}>
               <img
                 src={image}
                 alt={`${project.title} thumbnail ${index + 1}`}
                 className="w-full h-20 object-cover rounded cursor-pointer"
+                onError={(e) => { e.currentTarget.src = 'https://via.placeholder.com/150?text=No+Thumb'; }}
               />
             </SwiperSlide>
           ))}
         </Swiper>
 
-        <p className="mb-4 text-black dark:text-neutral-400 mt-6 text-center">
-          {t(`descriptions.${project.title}`)}
+        <p className="mb-4 text-black dark:text-neutral-400 mt-6 text-center max-w-2xl">
+          {displayDescription}
         </p>
 
         <div className="flex flex-wrap justify-center gap-2 mb-4">
-          {project.technologies.map((tech, index) => (
-            <span
-              key={index}
-              className="px-2 py-1 rounded bg-neutral-900 text-sm font-medium text-purple-800"
-            >
+          {project.technologies?.map((tech, index) => (
+            <span key={index} className="px-2 py-1 rounded bg-neutral-900 text-sm font-medium text-purple-800">
               {tech}
             </span>
           ))}
         </div>
 
-        <a
-          href={project.link}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-black dark:text-blue-500 underline"
-        >
+        <a href={project.link} target="_blank" rel="noopener noreferrer" className="text-black dark:text-blue-500 underline font-bold mt-2">
           {t("Visit Project")}
         </a>
       </div>
@@ -103,4 +109,3 @@ const ProjectDetails = () => {
 };
 
 export default ProjectDetails;
-


### PR DESCRIPTION
Introduce a serverless API endpoint (/api/projects) that fetches project metadata (portfolio.json) from specified GitHub repos. Add ProjectsContext (ProjectsProvider) to merge local PROJECTS with dynamic projects and expose loading state. Wrap App with ProjectsProvider in main.jsx. Update Projects and ProjectDetails components to consume the context, support dynamic project slugs, images and descriptions, show loading/fallback UI, and add image error fallbacks and optional chaining for safety. Overall enables loading and displaying projects hosted in external GitHub repositories alongside local projects.